### PR TITLE
iOS向けにビルドできるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,22 @@ pip-log.txt
 .mr.developer.cfg
 
 *.apk
+
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/
+*.hmap
+*.xccheckout

--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ DerivedData
 .idea/
 *.hmap
 *.xccheckout
+
+!proj.ios/Prefix.pch

--- a/Classes/GameScene.cpp
+++ b/Classes/GameScene.cpp
@@ -1,7 +1,14 @@
 #include "GameScene.h"
 #include "AppMacros.h"
-#include "AdMobUtil.h"
 #include "SimpleAudioEngine.h"
+
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+
+#define ENABLE_ADMOB
+#include "AdMobUtil.h"
+
+#endif
+
 USING_NS_CC;
 using namespace CocosDenshion;
 
@@ -217,7 +224,11 @@ void GameScene::update(float dt)
 void GameScene::startGame()
 {
     deleteTitle();
+
+#ifdef ENABLE_ADMOB
     AdMobUtil::hideAdView();
+#endif
+
     makeLabel();
     isGame = true;
     scheduleUpdate();
@@ -457,7 +468,11 @@ void GameScene::checkCollision()
 void GameScene::gameOver()
 {
     isGame = false;
+
+#ifdef ENABLE_ADMOB
     AdMobUtil::showAdView();
+#endif
+
     gameOverAnimation();
 
     CCObject* child = NULL;

--- a/proj.ios/Info.plist
+++ b/proj.ios/Info.plist
@@ -42,8 +42,7 @@
 	<array/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 </dict>
 </plist>

--- a/proj.ios/Prefix.pch
+++ b/proj.ios/Prefix.pch
@@ -1,0 +1,8 @@
+//
+// Prefix header for all source files of the 'iphone' target in the 'iphone' project
+//
+
+#ifdef __OBJC__
+    #import <Foundation/Foundation.h>
+    #import <UIKit/UIKit.h>
+#endif

--- a/proj.ios/dropMan.xcodeproj/project.pbxproj
+++ b/proj.ios/dropMan.xcodeproj/project.pbxproj
@@ -163,9 +163,6 @@
 		1ACB3244164770DE00914215 /* libcurl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ACB3243164770DE00914215 /* libcurl.a */; };
 		1AFAF8B716D35DE700DB1158 /* AppDelegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AFAF8B316D35DE700DB1158 /* AppDelegate.cpp */; };
 		1AFAF8B816D35DE700DB1158 /* HelloWorldScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AFAF8B516D35DE700DB1158 /* HelloWorldScene.cpp */; };
-		1AFAF8BC16D35E4900DB1158 /* CloseNormal.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AFAF8B916D35E4900DB1158 /* CloseNormal.png */; };
-		1AFAF8BD16D35E4900DB1158 /* CloseSelected.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AFAF8BA16D35E4900DB1158 /* CloseSelected.png */; };
-		1AFAF8BE16D35E4900DB1158 /* HelloWorld.png in Resources */ = {isa = PBXBuildFile; fileRef = 1AFAF8BB16D35E4900DB1158 /* HelloWorld.png */; };
 		1AFCDA8216D4A25900906EA6 /* RootViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AFCDA8116D4A25900906EA6 /* RootViewController.mm */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
@@ -580,9 +577,6 @@
 		1AFAF8B416D35DE700DB1158 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ../Classes/AppDelegate.h; sourceTree = "<group>"; };
 		1AFAF8B516D35DE700DB1158 /* HelloWorldScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HelloWorldScene.cpp; path = ../Classes/HelloWorldScene.cpp; sourceTree = "<group>"; };
 		1AFAF8B616D35DE700DB1158 /* HelloWorldScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HelloWorldScene.h; path = ../Classes/HelloWorldScene.h; sourceTree = "<group>"; };
-		1AFAF8B916D35E4900DB1158 /* CloseNormal.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CloseNormal.png; sourceTree = "<group>"; };
-		1AFAF8BA16D35E4900DB1158 /* CloseSelected.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = CloseSelected.png; sourceTree = "<group>"; };
-		1AFAF8BB16D35E4900DB1158 /* HelloWorld.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = HelloWorld.png; sourceTree = "<group>"; };
 		1AFCDA8016D4A25900906EA6 /* RootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootViewController.h; sourceTree = SOURCE_ROOT; };
 		1AFCDA8116D4A25900906EA6 /* RootViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RootViewController.mm; sourceTree = SOURCE_ROOT; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -1706,9 +1700,6 @@
 		78C7DDAA14EBA5050085D0C2 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				1AFAF8B916D35E4900DB1158 /* CloseNormal.png */,
-				1AFAF8BA16D35E4900DB1158 /* CloseSelected.png */,
-				1AFAF8BB16D35E4900DB1158 /* HelloWorld.png */,
 				D41A0AD0160F154A004552AE /* Default-568h@2x.png */,
 				7855E0DF153FEF240059DD9A /* Default.png */,
 				D446FD6D16102124000ADA7B /* Default@2x.png */,
@@ -1798,9 +1789,6 @@
 				D41A0AD1160F154A004552AE /* Default-568h@2x.png in Resources */,
 				D446FD6E16102124000ADA7B /* Default@2x.png in Resources */,
 				15A3D9961682F7F9002FB0C5 /* CMakeLists.txt in Resources */,
-				1AFAF8BC16D35E4900DB1158 /* CloseNormal.png in Resources */,
-				1AFAF8BD16D35E4900DB1158 /* CloseSelected.png in Resources */,
-				1AFAF8BE16D35E4900DB1158 /* HelloWorld.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/proj.ios/dropMan.xcodeproj/project.pbxproj
+++ b/proj.ios/dropMan.xcodeproj/project.pbxproj
@@ -162,7 +162,6 @@
 		1AC3624B16D4A1E8000847F2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AC3624516D4A1E8000847F2 /* main.m */; };
 		1ACB3244164770DE00914215 /* libcurl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ACB3243164770DE00914215 /* libcurl.a */; };
 		1AFAF8B716D35DE700DB1158 /* AppDelegate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AFAF8B316D35DE700DB1158 /* AppDelegate.cpp */; };
-		1AFAF8B816D35DE700DB1158 /* HelloWorldScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AFAF8B516D35DE700DB1158 /* HelloWorldScene.cpp */; };
 		1AFCDA8216D4A25900906EA6 /* RootViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AFCDA8116D4A25900906EA6 /* RootViewController.mm */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
@@ -223,6 +222,19 @@
 		379BB9D317F03F3700829B88 /* GUIReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 379BB99117F03F3700829B88 /* GUIReader.cpp */; };
 		379BB9D417F03F3700829B88 /* SceneReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 379BB99317F03F3700829B88 /* SceneReader.cpp */; };
 		46513EB1187BFBA200B5ABE1 /* UITouchGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46513EAF187BFBA200B5ABE1 /* UITouchGroup.cpp */; };
+		5734CF2D18BEFC8E00F948AA /* GameScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5734CF2A18BEFC8E00F948AA /* GameScene.cpp */; };
+		5734CF3118BEFEC700F948AA /* character.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF2F18BEFEC700F948AA /* character.png */; };
+		5734CF3D18BEFED200F948AA /* background.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3218BEFED200F948AA /* background.png */; };
+		5734CF3E18BEFED200F948AA /* background1.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3318BEFED200F948AA /* background1.png */; };
+		5734CF3F18BEFED200F948AA /* background2.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3418BEFED200F948AA /* background2.png */; };
+		5734CF4018BEFED200F948AA /* background3.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3518BEFED200F948AA /* background3.png */; };
+		5734CF4118BEFED200F948AA /* character.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3618BEFED200F948AA /* character.png */; };
+		5734CF4218BEFED200F948AA /* deadAnime01.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3718BEFED200F948AA /* deadAnime01.png */; };
+		5734CF4318BEFED200F948AA /* deadAnime02.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3818BEFED200F948AA /* deadAnime02.png */; };
+		5734CF4418BEFED200F948AA /* gameOver.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3918BEFED200F948AA /* gameOver.png */; };
+		5734CF4518BEFED200F948AA /* kabe.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3A18BEFED200F948AA /* kabe.png */; };
+		5734CF4618BEFED200F948AA /* title.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3B18BEFED200F948AA /* title.png */; };
+		5734CF4718BEFED200F948AA /* toge.png in Resources */ = {isa = PBXBuildFile; fileRef = 5734CF3C18BEFED200F948AA /* toge.png */; };
 		7855E0E1153FEF240059DD9A /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 7855E0DF153FEF240059DD9A /* Default.png */; };
 		BF171245129291EC00B8313A /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF170DB012928DE900B8313A /* OpenGLES.framework */; };
 		BF1712461292920000B8313A /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BF170DB212928DE900B8313A /* libxml2.dylib */; };
@@ -575,8 +587,6 @@
 		1ACB3243164770DE00914215 /* libcurl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcurl.a; path = ../../cocos2dx/platform/third_party/ios/libraries/libcurl.a; sourceTree = "<group>"; };
 		1AFAF8B316D35DE700DB1158 /* AppDelegate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AppDelegate.cpp; path = ../Classes/AppDelegate.cpp; sourceTree = "<group>"; };
 		1AFAF8B416D35DE700DB1158 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ../Classes/AppDelegate.h; sourceTree = "<group>"; };
-		1AFAF8B516D35DE700DB1158 /* HelloWorldScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HelloWorldScene.cpp; path = ../Classes/HelloWorldScene.cpp; sourceTree = "<group>"; };
-		1AFAF8B616D35DE700DB1158 /* HelloWorldScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HelloWorldScene.h; path = ../Classes/HelloWorldScene.h; sourceTree = "<group>"; };
 		1AFCDA8016D4A25900906EA6 /* RootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootViewController.h; sourceTree = SOURCE_ROOT; };
 		1AFCDA8116D4A25900906EA6 /* RootViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RootViewController.mm; sourceTree = SOURCE_ROOT; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -709,6 +719,21 @@
 		379BB99417F03F3700829B88 /* SceneReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneReader.h; sourceTree = "<group>"; };
 		46513EAF187BFBA200B5ABE1 /* UITouchGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UITouchGroup.cpp; sourceTree = "<group>"; };
 		46513EB0187BFBA200B5ABE1 /* UITouchGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UITouchGroup.h; sourceTree = "<group>"; };
+		5734CF2918BEFC8E00F948AA /* AppMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppMacros.h; path = ../Classes/AppMacros.h; sourceTree = "<group>"; };
+		5734CF2A18BEFC8E00F948AA /* GameScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameScene.cpp; path = ../Classes/GameScene.cpp; sourceTree = "<group>"; };
+		5734CF2B18BEFC8E00F948AA /* GameScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameScene.h; path = ../Classes/GameScene.h; sourceTree = "<group>"; };
+		5734CF2F18BEFEC700F948AA /* character.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = character.png; sourceTree = "<group>"; };
+		5734CF3218BEFED200F948AA /* background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = background.png; path = L/background.png; sourceTree = "<group>"; };
+		5734CF3318BEFED200F948AA /* background1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = background1.png; path = L/background1.png; sourceTree = "<group>"; };
+		5734CF3418BEFED200F948AA /* background2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = background2.png; path = L/background2.png; sourceTree = "<group>"; };
+		5734CF3518BEFED200F948AA /* background3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = background3.png; path = L/background3.png; sourceTree = "<group>"; };
+		5734CF3618BEFED200F948AA /* character.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = character.png; path = L/character.png; sourceTree = "<group>"; };
+		5734CF3718BEFED200F948AA /* deadAnime01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = deadAnime01.png; path = L/deadAnime01.png; sourceTree = "<group>"; };
+		5734CF3818BEFED200F948AA /* deadAnime02.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = deadAnime02.png; path = L/deadAnime02.png; sourceTree = "<group>"; };
+		5734CF3918BEFED200F948AA /* gameOver.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = gameOver.png; path = L/gameOver.png; sourceTree = "<group>"; };
+		5734CF3A18BEFED200F948AA /* kabe.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = kabe.png; path = L/kabe.png; sourceTree = "<group>"; };
+		5734CF3B18BEFED200F948AA /* title.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = title.png; path = L/title.png; sourceTree = "<group>"; };
+		5734CF3C18BEFED200F948AA /* toge.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = toge.png; path = L/toge.png; sourceTree = "<group>"; };
 		7855E0DF153FEF240059DD9A /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = SOURCE_ROOT; };
 		BF170DB012928DE900B8313A /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		BF170DB212928DE900B8313A /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
@@ -1244,8 +1269,9 @@
 			children = (
 				1AFAF8B316D35DE700DB1158 /* AppDelegate.cpp */,
 				1AFAF8B416D35DE700DB1158 /* AppDelegate.h */,
-				1AFAF8B516D35DE700DB1158 /* HelloWorldScene.cpp */,
-				1AFAF8B616D35DE700DB1158 /* HelloWorldScene.h */,
+				5734CF2918BEFC8E00F948AA /* AppMacros.h */,
+				5734CF2A18BEFC8E00F948AA /* GameScene.cpp */,
+				5734CF2B18BEFC8E00F948AA /* GameScene.h */,
 			);
 			name = Classes;
 			path = ../classes;
@@ -1707,6 +1733,18 @@
 				D4EF949F15BD2D9800D803EB /* Icon-144.png */,
 				D4EF949915BD2D8B00D803EB /* Icon-57.png */,
 				D4EF949D15BD2D9600D803EB /* Icon-72.png */,
+				5734CF2F18BEFEC700F948AA /* character.png */,
+				5734CF3218BEFED200F948AA /* background.png */,
+				5734CF3318BEFED200F948AA /* background1.png */,
+				5734CF3418BEFED200F948AA /* background2.png */,
+				5734CF3518BEFED200F948AA /* background3.png */,
+				5734CF3618BEFED200F948AA /* character.png */,
+				5734CF3718BEFED200F948AA /* deadAnime01.png */,
+				5734CF3818BEFED200F948AA /* deadAnime02.png */,
+				5734CF3918BEFED200F948AA /* gameOver.png */,
+				5734CF3A18BEFED200F948AA /* kabe.png */,
+				5734CF3B18BEFED200F948AA /* title.png */,
+				5734CF3C18BEFED200F948AA /* toge.png */,
 			);
 			name = Resources;
 			path = ../Resources;
@@ -1783,12 +1821,24 @@
 			files = (
 				7855E0E1153FEF240059DD9A /* Default.png in Resources */,
 				D4EF949A15BD2D8B00D803EB /* Icon-57.png in Resources */,
+				5734CF4718BEFED200F948AA /* toge.png in Resources */,
+				5734CF4118BEFED200F948AA /* character.png in Resources */,
 				D4EF949C15BD2D8E00D803EB /* Icon-114.png in Resources */,
 				D4EF949E15BD2D9600D803EB /* Icon-72.png in Resources */,
 				D4EF94A015BD2D9800D803EB /* Icon-144.png in Resources */,
+				5734CF4318BEFED200F948AA /* deadAnime02.png in Resources */,
 				D41A0AD1160F154A004552AE /* Default-568h@2x.png in Resources */,
 				D446FD6E16102124000ADA7B /* Default@2x.png in Resources */,
+				5734CF3E18BEFED200F948AA /* background1.png in Resources */,
+				5734CF3118BEFEC700F948AA /* character.png in Resources */,
+				5734CF4518BEFED200F948AA /* kabe.png in Resources */,
+				5734CF4218BEFED200F948AA /* deadAnime01.png in Resources */,
+				5734CF4618BEFED200F948AA /* title.png in Resources */,
+				5734CF3D18BEFED200F948AA /* background.png in Resources */,
 				15A3D9961682F7F9002FB0C5 /* CMakeLists.txt in Resources */,
+				5734CF3F18BEFED200F948AA /* background2.png in Resources */,
+				5734CF4018BEFED200F948AA /* background3.png in Resources */,
+				5734CF4418BEFED200F948AA /* gameOver.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1929,11 +1979,11 @@
 				15A3DAEB1682F8A6002FB0C5 /* CDAudioManager.m in Sources */,
 				15A3DAEC1682F8A6002FB0C5 /* CDOpenALSupport.m in Sources */,
 				15A3DAED1682F8A6002FB0C5 /* CocosDenshion.m in Sources */,
+				5734CF2D18BEFC8E00F948AA /* GameScene.cpp in Sources */,
 				15A3DAEE1682F8A6002FB0C5 /* SimpleAudioEngine.mm in Sources */,
 				15A3DAEF1682F8A6002FB0C5 /* SimpleAudioEngine_objc.m in Sources */,
 				1A27573F1697CF2B00504026 /* CCEditBoxImplAndroid.cpp in Sources */,
 				1AFAF8B716D35DE700DB1158 /* AppDelegate.cpp in Sources */,
-				1AFAF8B816D35DE700DB1158 /* HelloWorldScene.cpp in Sources */,
 				1AC3624916D4A1E8000847F2 /* AppController.mm in Sources */,
 				1AC3624B16D4A1E8000847F2 /* main.m in Sources */,
 				1AFCDA8216D4A25900906EA6 /* RootViewController.mm in Sources */,

--- a/proj.ios/dropMan.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/proj.ios/dropMan.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:dropMan.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Xcode プロジェクトの設定などをおこなってiOS向けにビルドできるようにしました。
画像リソースのサイズなどの調整は必要そうだけど、とりあえずビルドできるように。
AdMob のところはプラットフォームを見て、とりあえずiOSでは無効にしておきました。
